### PR TITLE
Make the script compatible with nodejs.

### DIFF
--- a/js/JPContext.js
+++ b/js/JPContext.js
@@ -207,16 +207,14 @@ JPDeclarationContext.prototype.parse = function(){
 
 /////////////////exports
 
-exports = {
-	JPCommonContext: JPCommonContext,
-	JPMsgContext: JPMsgContext,
-	JPParamContext: JPParamContext,
-	JPBlockContext: JPBlockContext,
-	JPBlockContentContext: JPBlockContentContext,
-	JPAssignContext: JPAssignContext,
-	JPAssignLeftContext: JPAssignLeftContext,
-	JPAssignRightContext: JPAssignRightContext,
-	JPDeclarationContext: JPDeclarationContext,
-	JPClassContext: JPClassContext,
-	JPMethodContext: JPMethodContext,
-};
+exports.JPCommonContext = JPCommonContext;
+exports.JPMsgContext = JPMsgContext;
+exports.JPParamContext = JPParamContext;
+exports.JPBlockContext = JPBlockContext;
+exports.JPBlockContentContext = JPBlockContentContext;
+exports.JPAssignContext = JPAssignContext;
+exports.JPAssignLeftContext = JPAssignLeftContext;
+exports.JPAssignRightContext = JPAssignRightContext;
+exports.JPDeclarationContext = JPDeclarationContext;
+exports.JPClassContext = JPClassContext;
+exports.JPMethodContext = JPMethodContext;


### PR DESCRIPTION
`exprots = {xx:xx}` does not work with nodejs, fix it.
