### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,18 +1,18 @@
-#JSPatch Convertor
+# JSPatch Convertor
 
 JSPatch Convertor 可以自动把 Objective-C 代码转为 JSPatch 脚本。( [什么是 JSPatch ?](https://github.com/bang590/JSPatch) )
 
-##使用
+## 使用
 
 在线使用： [http://bang590.github.io/JSPatchConvertor](http://bang590.github.io/JSPatchConvertor)
 
 请使用 Chrome 或 Safari 浏览器。
 
-##功能
+## 功能
 
 JSPatch Convertor 实现了 Objective-C 以下语法特性的转换：
 
-####方法定义
+#### 方法定义
 ```objc
 - (void)requestUrl:(NSString *)url param:(NSDictionary *)dict {}
 ```
@@ -21,7 +21,7 @@ JSPatch Convertor 实现了 Objective-C 以下语法特性的转换：
 requestUrl_param: function(url, dict) {}
 ```
 
-####方法调用
+#### 方法调用
 ```objc
 [[JPRequest alloc] initWithUrl:url param:dict];
 ```
@@ -29,7 +29,7 @@ requestUrl_param: function(url, dict) {}
 JPRequest.alloc().initWithUrl_param(url, dict);
 ```
 
-####Block 语法
+#### Block 语法
 ```objc
 [JPRquest handleCallback:^(id data, NSError *err) {}];
 ```
@@ -38,7 +38,7 @@ JPRquest.handleCallback(block('id,NSError*', function(data, err) {}));
 ```
 
 
-####变量声明
+#### 变量声明
 ```objc
 NSString *str = @"content";
 ```
@@ -46,7 +46,7 @@ NSString *str = @"content";
 var str = "content";
 ```
 
-####Getting/Setting Property
+#### Getting/Setting Property
 ```objc
 self.handler.successBlock(data);
 self.handler.data = [[JPData alloc] init];
@@ -56,7 +56,7 @@ self.handler().successBlock()(data);
 self.handler().setData(JPData.alloc().init());
 ```
 
-####NSString / NSArray / nil ...
+#### NSString / NSArray / nil ...
 ```objc
 NSDictionary *dict = nil;
 dict = @{
@@ -71,7 +71,7 @@ dict = {
 ```
 
 
-#限制
+# 限制
 
 JSPatch Convertor 没有处理以下 Objective-C 语法特性的转换，若要转换的代码里有这些特性，会原样输出到转换后的 JSPatch 脚本上，需要人工再进行处理：
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-#JSPatch Convertor
+# JSPatch Convertor
 
 JSPatch Convertor is a tool that converts Objective-C code to JSPatch script automatically.   
 ( [What's JSPatch?](https://github.com/bang590/JSPatch) )
 
-##Usage
+## Usage
 
 Check out [http://bang590.github.io/JSPatchConvertor](http://bang590.github.io/JSPatchConvertor)
 
 Please use Chrome or Safari.
 
-#####Advice: You can also download Mac Application:
+##### Advice: You can also download Mac Application:
 
 Click: https://github.com/DevSonw/JSPatchConvertor/blob/gh-pages/JSPatchConvertor.zip
 
-##Supported
+## Supported
 
 The Objective-C syntax below is supported to convert：
 
-####Method declaration
+#### Method declaration
 ```objc
 - (void)requestUrl:(NSString *)url param:(NSDictionary *)dict {}
 ```
@@ -25,7 +25,7 @@ The Objective-C syntax below is supported to convert：
 requestUrl_param: function(url, dict) {}
 ```
 
-####Method calling
+#### Method calling
 ```objc
 [[JPRequest alloc] initWithUrl:url param:dict];
 ```
@@ -33,7 +33,7 @@ requestUrl_param: function(url, dict) {}
 JPRequest.alloc().initWithUrl_param(url, dict);
 ```
 
-####Block syntax
+#### Block syntax
 ```objc
 [JPRquest handleCallback:^(id data, NSError *err) {}];
 ```
@@ -42,7 +42,7 @@ JPRquest.handleCallback(block('id,NSError*', function(data, err) {}));
 ```
 
 
-####Variable declaration
+#### Variable declaration
 ```objc
 NSString *str = @"content";
 ```
@@ -50,7 +50,7 @@ NSString *str = @"content";
 var str = "content";
 ```
 
-####Getting/Setting Property
+#### Getting/Setting Property
 ```objc
 self.handler.successBlock(data);
 self.handler.data = [[JPData alloc] init];
@@ -60,7 +60,7 @@ self.handler().successBlock()(data);
 self.handler().setData(JPData.alloc().init());
 ```
 
-####NSString / NSArray / nil ...
+#### NSString / NSArray / nil ...
 ```objc
 NSDictionary *dict = nil;
 dict = @{
@@ -74,7 +74,7 @@ dict = {
 };
 ```
 
-#Unsupported
+# Unsupported
 
 JSPatch Convertor didn't support the Objective-C / C syntax below, you should modify it manually after converted:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
